### PR TITLE
Disable network wait during boot for offline Pi setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The installer is intended for a headless Raspberry Pi (no desktop environment) w
 * **Volume-based frequency changes** – Monitors Bluetooth absolute volume changes and repurposes the phone volume keys to bump the FM frequency by a configurable step.
 * **AVRCP metadata to RDS** – Mirrors track metadata (Artist, Title, Album) into the RDS PS/RT fields.
 * **LED status feedback** – Reconfigures the Raspberry Pi ACT LED and provides visual cues for pairing, connection, streaming, and frequency adjustments.
+* **Offline-friendly boot** – Disables the "wait for network" delay so the Pi completes startup even without network connectivity.
 
 ## Hardware requirements
 
@@ -29,7 +30,7 @@ The installer is intended for a headless Raspberry Pi (no desktop environment) w
 The script targets Raspberry Pi OS (Debian-based). It expects:
 
 * `sudo` access to run as root (the script exits if not run with `sudo`).
-* Network connectivity for `apt-get` and cloning PiFmRds from GitHub.
+* Network connectivity for `apt-get` and cloning PiFmRds from GitHub during installation (the system will no longer wait for a network connection on subsequent boots).
 * Python 3 with GObject introspection libraries (installed automatically).
 
 All required packages are installed automatically via `apt-get` when you run the installer.

--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -33,6 +33,18 @@ apt-get update -y
 apt-get install -y git build-essential libsndfile1-dev python3-dbus python3-gi dbus \
                    bluez bluez-tools bluez-alsa alsa-utils sox jq libttspico-utils espeak-ng gawk
 
+echo "==> Skip boot wait for network (offline-friendly)"
+if command -v raspi-config >/dev/null 2>&1; then
+  raspi-config nonint do_boot_wait 0 || true
+else
+  systemctl disable --now systemd-networkd-wait-online.service 2>/dev/null || true
+  systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
+  systemctl disable --now NetworkManager-wait-online.service 2>/dev/null || true
+  systemctl mask NetworkManager-wait-online.service 2>/dev/null || true
+  systemctl disable --now dhcpcd-wait-online.service 2>/dev/null || true
+  systemctl mask dhcpcd-wait-online.service 2>/dev/null || true
+fi
+
 echo "==> Headless BT setup (discoverable + pairable on boot)"
 cat >/etc/systemd/system/bt-setup.service <<'EOF'
 [Unit]


### PR DESCRIPTION
## Summary
- disable waiting for a network connection during boot so offline deployments continue starting
- document the new offline-friendly behavior in the README and clarify install-time network needs

## Testing
- bash -n a2dp2fm.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1e9b5ef8483249ca65d8b34cca1d9