### PR TITLE
Add tag metadata to script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a single installer script, `a2dp2fm.sh`, that configure
 
 The installer is intended for a headless Raspberry Pi (no desktop environment) with a Bluetooth adapter and speaker/headphone audio disabled. After installation you can pair a phone with the Pi, stream audio over Bluetooth, and receive the broadcast on a nearby FM radio tuned to your configured frequency.
 
+## Tags
+
+`raspberry-pi` · `bluetooth` · `a2dp` · `fm-transmitter` · `rds` · `pi-fm-rds` · `headless-install` · `systemd` · `tts`
+
 ## Features
 
 * **Fully automated provisioning** – Installs all required packages, clones PiFmRds, builds the transmitter, and configures systemd units in one pass.

--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # install_bt_fm_rds_with_led.sh
 # Headless Bluetooth A2DP -> PiFmRds (FM on GPIO4) + Volume-key freq control + TTS announce + AVRCP->RDS + LED status
+# Tags: raspberry-pi, bluetooth, a2dp, fm-transmitter, rds, pi-fm-rds, headless-install, systemd, tts
 # Usage: sudo bash install_bt_fm_rds_with_led.sh [--freq 87.9] [--step 0.2] [--min 87.7] [--max 107.9]
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- add a tag metadata comment to the installer script header for quick topical context
- document the repository keywords in the README to improve discoverability

## Testing
- bash -n a2dp2fm.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1eaba79548324b5875120f0330488