### PR TITLE
Add requirements manifest for Python helper dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The script targets Raspberry Pi OS (Debian-based). It expects:
 
 All required packages are installed automatically via `apt-get` when you run the installer.
 
+If you want to work with the Python helper (`avrcp_rds.py`) outside of the
+installer flow, the Python dependencies are listed in `requirements.txt`. The
+modules are shipped by Raspberry Pi OS via `apt-get` (`python3-dbus` and
+`python3-gi`), but the requirement file is provided for tooling that inspects
+Python dependencies.
+
 ## Installation
 
 1. **Run directly with `curl` (optional).** For a one-liner install on a freshly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python dependencies used by /usr/local/bin/avrcp_rds.py
+# Installed automatically via apt-get (python3-dbus, python3-gi)
+dbus-python
+PyGObject


### PR DESCRIPTION
## Summary
- add a requirements.txt manifest covering the Python helper's dependencies
- document the new manifest in the README for developers and tooling

## Testing
- bash -n a2dp2fm.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1ebb5660c8324a7d6b9b7993b51c0