### PR TITLE
Handle bluealsa package rename

### DIFF
--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -34,8 +34,17 @@ RDSCTL="/run/rds_ctl"
 echo "==> Apt install (Bluetooth, audio, PiFmRds deps, TTS, tools)"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
+BLUEALSA_PKG="bluealsa"
+if ! apt-cache show "$BLUEALSA_PKG" >/dev/null 2>&1; then
+  if apt-cache show bluez-alsa >/dev/null 2>&1; then
+    BLUEALSA_PKG="bluez-alsa"
+  else
+    echo "Neither bluealsa nor bluez-alsa is available in APT repositories." >&2
+    exit 1
+  fi
+fi
 apt-get install -y git build-essential libsndfile1-dev python3-dbus python3-gi dbus \
-                   bluez bluez-tools bluez-alsa alsa-utils sox jq libttspico-utils espeak-ng gawk
+                   bluez bluez-tools "$BLUEALSA_PKG" alsa-utils sox jq libttspico-utils espeak-ng gawk
 
 echo "==> Skip boot wait for network (offline-friendly)"
 if command -v raspi-config >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- detect whether the bluealsa package is available under the modern or legacy name before installing dependencies
- fail fast with a clear message if neither package is found so the installer does not continue in a broken state

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1fe1093308324808b2cb0e8d7d02b