### PR TITLE
Build BlueALSA from source when apt package missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Python dependencies.
 
 4. **Wait for the script to finish.** It performs the following actions:
 
-   * Installs Bluetooth, audio, PiFmRds build dependencies, speech synthesis utilities, and helper tools via `apt-get`.
+   * Installs Bluetooth, audio, PiFmRds build dependencies, speech synthesis utilities, and helper tools via `apt-get`, preferring packaged BlueALSA (`bluealsa`/`bluez-alsa`) when available and otherwise compiling the [Arkq/bluez-alsa](https://github.com/Arkq/bluez-alsa) source release automatically.
    * Creates a `bt-setup.service` systemd unit that powers on the adapter, enables the agent, and sets the controller to be discoverable/pairable on boot.
    * Clones PiFmRds into `/home/${SUDO_USER:-pi}/PiFmRds` (the invoking sudo user's home) and builds `pi_fm_rds`.
    * Stores runtime defaults in `/etc/default/bt2fm` using the values you provided.

--- a/tests/bin/git-clone-stub
+++ b/tests/bin/git-clone-stub
@@ -3,19 +3,64 @@
 # location earlier in PATH (e.g. /usr/local/bin/git) before running the installer in
 # environments where outbound HTTPS is blocked.
 set -euo pipefail
+
 if [[ ${1:-} == clone ]]; then
   dest="${@: -1}"
   rm -rf "$dest"
-  mkdir -p "$dest/src"
-  {
-    printf 'all:\n'
-    printf '\t@echo "[stub make] building pi_fm_rds"\n'
-    printf '\t@printf '\''#!/usr/bin/env bash\\n'\'' > pi_fm_rds\n'
-    printf '\t@printf '\''echo stub-pi_fm_rds exec\\\\n'\'' >> pi_fm_rds\n'
-    printf '\t@chmod +x pi_fm_rds\n'
-    printf 'clean:\n'
-    printf '\t@rm -f pi_fm_rds\n'
-  } >"$dest/src/Makefile"
+  mkdir -p "$dest"
+  case "$dest" in
+    *PiFmRds*)
+      mkdir -p "$dest/src"
+      cat <<'MAKE' >"$dest/src/Makefile"
+all:
+	@echo "[stub make] building pi_fm_rds"
+	@echo '#!/usr/bin/env bash' > pi_fm_rds
+	@echo 'echo stub-pi_fm_rds exec' >> pi_fm_rds
+	@chmod +x pi_fm_rds
+clean:
+	@rm -f pi_fm_rds
+MAKE
+      ;;
+    *bluez-alsa*)
+      cat <<'BOOT' >"$dest/bootstrap"
+#!/usr/bin/env bash
+exit 0
+BOOT
+      chmod +x "$dest/bootstrap"
+      cat <<'CONF' >"$dest/configure"
+#!/usr/bin/env bash
+set -euo pipefail
+prefix="/usr/local"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix=*) prefix="${1#*=}" ;;
+    --disable-hcitop) ;;
+  esac
+  shift || true
+done
+cat >Makefile <<MAKE
+PREFIX ?= ${prefix}
+bindir = \$(PREFIX)/bin
+
+all:
+	@echo "[stub make] building bluealsa"
+
+install:
+	@mkdir -p \$(DESTDIR)\$(bindir)
+	@echo '#!/usr/bin/env bash' > \$(DESTDIR)\$(bindir)/bluealsa
+	@echo 'exit 0' >> \$(DESTDIR)\$(bindir)/bluealsa
+	@chmod +x \$(DESTDIR)\$(bindir)/bluealsa
+	@ln -sf bluealsa \$(DESTDIR)\$(bindir)/bluealsad
+
+clean:
+	@echo "[stub make] clean bluealsa"
+MAKE
+exit 0
+CONF
+      chmod +x "$dest/configure"
+      ;;
+  esac
   exit 0
 fi
+
 exec /usr/bin/git "$@"


### PR DESCRIPTION
## Summary
- prefer packaged BlueALSA when available and automatically build Arkq/bluez-alsa from source when no apt candidate exists
- expand the installer to locate the BlueALSA daemon, create a service unit when needed, and include the additional build dependencies
- update the test harness and git stub so the source build path is exercised and validated in CI

## Testing
- sudo tests/run-install-test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e200a62f308324b44b4b41d04c8a85