### PR TITLE
Ensure Bluetooth remains discoverable

### DIFF
--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -188,6 +188,8 @@ bluetoothctl <<'BCTL'
 agent on
 default-agent
 power on
+discoverable-timeout 0
+pairable-timeout 0
 discoverable on
 pairable on
 BCTL


### PR DESCRIPTION
## Summary
- ensure the bt-setup helper disables discoverable/pairable timeouts so the Pi keeps advertising indefinitely

## Testing
- ./tests/run-install-test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e293a0049c8324980947f13137a9b7