### PR TITLE
Handle rfkill soft block before bluetoothctl setup

### DIFF
--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -199,6 +199,18 @@ echo "==> Headless BT setup (discoverable + pairable on boot)"
 cat >/usr/local/sbin/bt-setup-bluetooth.sh <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if command -v rfkill >/dev/null 2>&1; then
+  while rfkill list bluetooth 2>/dev/null | grep -qi 'Soft blocked: yes'; do
+    rfkill unblock bluetooth || true
+    sleep 1
+  done
+fi
+
+systemctl restart bluetooth.service || true
+if systemctl list-unit-files 2>/dev/null | grep -q '^hciuart\.service'; then
+  systemctl restart hciuart.service || true
+fi
 bluetoothctl <<'BCTL'
 agent on
 default-agent


### PR DESCRIPTION
## Summary
- ensure the bt-setup helper clears any rfkill soft block before running bluetoothctl
- restart bluetooth (and hciuart when available) so the adapter reinitializes prior to configuration

## Testing
- bash -n a2dp2fm.sh

------
https://chatgpt.com/codex/tasks/task_e_68e29bf7dd7883248881af5fe54732e1