### PR TITLE
Add ARMv7 Docker harness for installer tests

### DIFF
--- a/tests/Dockerfile.rpi-sim
+++ b/tests/Dockerfile.rpi-sim
@@ -1,0 +1,33 @@
+# Lightweight Raspberry Pi–like container for exercising the installer under QEMU
+#
+# This image targets ARMv7 (32-bit) to mirror common Raspberry Pi builds while
+# remaining runnable on amd64 hosts via qemu-user-static. It intentionally keeps
+# the package set small because the installer pulls its own dependencies.
+
+FROM multiarch/qemu-user-static:latest AS qemu
+
+FROM --platform=linux/arm/v7 debian:bookworm-slim
+
+# Copy the QEMU emulator so amd64 hosts can run the ARMv7 userspace.
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Core utilities plus sudo (the installer expects sudo semantics when invoked as root).
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+       bash \
+       sudo \
+       ca-certificates \
+       curl \
+       git \
+       passwd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Provide a place for stub logs when running tests and make sure the default
+# /run directory exists for FIFO creation inside containers.
+RUN mkdir -p /var/log/a2dp2fm /run
+
+WORKDIR /workspace
+
+ENTRYPOINT ["bash"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,26 @@ validated.
 Each shim logs its invocations to `$A2DP2FM_STUB_LOG_DIR` so you can audit what would
 have been executed on a real Raspberry Pi. Remove the directory afterwards if desired.
 
+## Raspberry Pi–like container for automated checks
+
+The repository includes a slim ARMv7 container to mimic a Raspberry Pi userspace
+while running on amd64 hosts via QEMU. Build and run the installer test inside the
+container with:
+
+```bash
+./tests/run-in-docker.sh
+```
+
+Environment variables to tweak the run:
+
+* `A2DP2FM_RPI_IMAGE` – Override the Docker image tag (default: `a2dp2fm-rpi-sim`).
+* `DOCKER_BUILD_ARGS` – Extra arguments forwarded to `docker build`.
+* `DOCKER_RUN_ARGS` – Extra arguments forwarded to `docker run`.
+
+The container uses the stubbed utilities in `tests/bin`, runs the installer against
+an ARMv7 Debian Bookworm base, and verifies that expected artifacts are emitted. This
+is the fastest way to sanity-check changes when you do not have a physical Pi handy.
+
 ## Automated merge test
 
 Run `tests/run-install-test.sh` to execute the installer against the shims and verify

--- a/tests/run-in-docker.sh
+++ b/tests/run-in-docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build and run the ARMv7 test container so we can exercise the installer under QEMU.
+#
+# Usage: ./tests/run-in-docker.sh
+# Optional environment variables:
+#   A2DP2FM_RPI_IMAGE   Name for the built image (default: a2dp2fm-rpi-sim)
+#   DOCKER_BUILD_ARGS   Extra args passed to docker build (e.g. --no-cache)
+#   DOCKER_RUN_ARGS     Extra args passed to docker run
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_NAME="${A2DP2FM_RPI_IMAGE:-a2dp2fm-rpi-sim}"
+DOCKER_BIN="${DOCKER:-docker}"
+
+echo "Building ARMv7 test image ($IMAGE_NAME)..."
+$DOCKER_BIN build ${DOCKER_BUILD_ARGS:-} -f "$SCRIPT_DIR/Dockerfile.rpi-sim" -t "$IMAGE_NAME" "$REPO_ROOT"
+
+# Run privileged so tools like useradd can manipulate /etc/shadow without container restrictions.
+echo "Running installer test inside container..."
+$DOCKER_BIN run --rm --privileged ${DOCKER_RUN_ARGS:-} \
+  -v "$REPO_ROOT:/workspace" \
+  -w /workspace \
+  "$IMAGE_NAME" \
+  bash tests/run-install-test.sh


### PR DESCRIPTION
## Summary
- add an ARMv7 Dockerfile that embeds qemu-user-static to mimic Raspberry Pi userspace
- provide a helper script to build the image and run the installer test inside the container
- document how to invoke the containerized test harness for quick verification

## Testing
- tests/run-install-test.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936337b35b48324934f6ca1f8f701cb)