### PR TITLE
Make git clone command configurable for offline runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ The script targets Raspberry Pi OS (Debian-based). It expects:
 
 All required packages are installed automatically via `apt-get` when you run the installer.
 
+To emulate an install inside a network-restricted container (e.g. CI), you can point the
+installer at the bundled offline-friendly Git stub while keeping the other shim utilities
+on `PATH`:
+
+```bash
+A2DP2FM_STUB_LOG_DIR=$(mktemp -d) \
+  PATH="$(pwd)/tests/bin:$PATH" \
+  A2DP2FM_GIT_CLONE_CMD="$(pwd)/tests/bin/git-clone-stub" \
+  SUDO_USER=pi sudo ./a2dp2fm.sh --freq 99.1
+```
+
+The stub satisfies `git clone` calls without reaching the public internet while logging
+activity under `$A2DP2FM_STUB_LOG_DIR`.
+
 ### OS compatibility (Trixie and earlier)
 
 The installer detects the underlying Raspberry Pi OS/Debian codename and prints it during execution. It is validated on Raspberry Pi OS **Trixie**, **Bookworm**, and **Bullseye** (and should continue to work on earlier codenames such as Buster). Newer or derivative distributions may still succeed, but will emit a warning so you know compatibility has not been verified. Both `/boot/config.txt` and `/boot/firmware/config.txt` are updated, covering the boot layout used by recent Raspberry Pi OS releases.

--- a/a2dp2fm.sh
+++ b/a2dp2fm.sh
@@ -46,6 +46,7 @@ PI_HOME="$(getent passwd "$PI_USER" | cut -d: -f6 2>/dev/null || true)"
 if [[ -z "${PI_HOME:-}" ]]; then
   PI_HOME="/home/$PI_USER"
 fi
+GIT_CLONE_CMD="${A2DP2FM_GIT_CLONE_CMD:-git}"
 PIFM_DIR="$PI_HOME/PiFmRds"
 RDSCTL="/run/rds_ctl"
 CFG_C1="/boot/config.txt"; CFG_C2="/boot/firmware/config.txt"
@@ -193,7 +194,7 @@ install_bluealsa_from_source() {
   echo "==> Build BlueALSA from source (Arkq/bluez-alsa)"
   mkdir -p "$(dirname "$dir")"
   rm -rf "$dir"
-  git clone --depth 1 "$repo" "$dir"
+  "$GIT_CLONE_CMD" clone --depth 1 "$repo" "$dir"
   pushd "$dir" >/dev/null
   if [[ -x ./bootstrap ]]; then
     ./bootstrap
@@ -364,7 +365,7 @@ systemctl start bt-setup.service || true
 
 echo "==> Clone & build PiFmRds"
 if [[ ! -d "$PIFM_DIR" ]]; then
-  sudo -u "$PI_USER" git clone https://github.com/ChristopheJacquet/PiFmRds.git "$PIFM_DIR"
+  sudo -u "$PI_USER" "$GIT_CLONE_CMD" clone https://github.com/ChristopheJacquet/PiFmRds.git "$PIFM_DIR"
 fi
 pushd "$PIFM_DIR/src" >/dev/null
 sudo -u "$PI_USER" make clean || true


### PR DESCRIPTION
## Summary
- allow overriding the git clone command used by the installer to support offline stubs
- document how to emulate installation in a network-restricted container using the git stub

## Testing
- ./tests/run-install-test.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936343a54688324b3bc1d61a99ca1c9)